### PR TITLE
Fixed scoping bug

### DIFF
--- a/SVGRenderer/src/com/lorentz/SVG/drawing/DashedDrawer.as
+++ b/SVGRenderer/src/com/lorentz/SVG/drawing/DashedDrawer.as
@@ -150,7 +150,7 @@ package com.lorentz.SVG.drawing
 				var dx:Number = x-penX
 				var dy:Number = y-penY;
 				
-				var lineLength:Number = lineLength(dx, dy);
+				var lineLength:Number = this.lineLength(dx, dy);
 				
 				var lengthToDraw:Number = Math.min(lineLength, getDashLength() - _dashDrawnLength);
 				


### PR DESCRIPTION
In DashedDrawer.lineTo, the variable lineLength is named the same as the
method lineLength. This causes the call to the lineLength (which is NaN)
to throw a "value is not a function" error.
