### PR TITLE
Fix polyline fill - do not ignore the "fill" property.

### DIFF
--- a/SVGRenderer/src/com/lorentz/SVG/display/SVGPolyline.as
+++ b/SVGRenderer/src/com/lorentz/SVG/display/SVGPolyline.as
@@ -16,10 +16,6 @@
 			_points = value;
 			invalidateRender();
 		}
-			
-		override protected function get hasFill():Boolean {
-			return isInClipPath();
-		}
 				
 		override protected function drawToDrawer(drawer:IDrawer):void {
 			if(points.length>2){


### PR DESCRIPTION
Is there a use case why we try to override the super getter?
