### PR TITLE
Ignore UseElement width, height, x and y if transform is used. Fixes for symbol transformations.

### DIFF
--- a/SVGRenderer/src/com/lorentz/SVG/display/SVGUse.as
+++ b/SVGRenderer/src/com/lorentz/SVG/display/SVGUse.as
@@ -89,6 +89,10 @@
 			}
 			
 			if(_includedElement){
+				if(svgTransform) {
+					svgX = svgY = null;
+					svgWidth = svgHeight = null;
+				}
 				_includedElement.x = svgX ? getViewPortUserUnit(svgX, SVGUtil.WIDTH) : 0;
 				_includedElement.y = svgY ? getViewPortUserUnit(svgY, SVGUtil.HEIGHT) : 0;
 				_includedElement.svgTransform += " " + svgTransform;


### PR DESCRIPTION
I might not cover all the use cases but it seems that these properties have to be used differently for UseElements or they have to be applied after transform:

The ‘use’ element has optional attributes ‘x’, ‘y’, ‘width’ and ‘height’ which are used to map the graphical contents of the referenced element onto a rectangular region within the current coordinate system.
http://www.w3.org/TR/SVG/struct.html#UseElement

The ‘transform’ attribute is applied to an element before processing any other coordinate or length values supplied for that element. In the element
http://www.w3.org/TR/SVG/coords.html#TransformAttribute
